### PR TITLE
Changes to basic Rdp code

### DIFF
--- a/simulations/RLSimulations/package.ned
+++ b/simulations/RLSimulations/package.ned
@@ -1,0 +1,3 @@
+package rdp.simulations.RLSimulation;
+
+@license(LGPL);

--- a/simulations/RLSimulations/package.ned
+++ b/simulations/RLSimulations/package.ned
@@ -1,3 +1,3 @@
-package rdp.simulations.RLSimulation;
+package rdp.simulations.RLSimulations;
 
 @license(LGPL);

--- a/simulations/RLSimulations/simplenetwork.ned
+++ b/simulations/RLSimulations/simplenetwork.ned
@@ -1,6 +1,6 @@
 
 
-package rdp.simulations.RLSimulation;
+package rdp.simulations.RLSimulations;
 
 @namespace(inet);
 @namespace(rdp);

--- a/simulations/RLSimulations/simplenetwork.ned
+++ b/simulations/RLSimulations/simplenetwork.ned
@@ -1,0 +1,64 @@
+
+
+package rdp.simulations.RLSimulation;
+
+@namespace(inet);
+@namespace(rdp);
+
+
+import rdp.node.StandardHostRdp;
+import ecmp.networklayer.configurator.ipv4.Ipv4NetworkConfiguratorEcmp;
+import inet.node.inet.Router;
+import rdp.base.RouterRdp;
+import ned.DatarateChannel;
+import ned.IBidirectionalChannel;
+import model.Broker;
+import model.Stepper;
+
+network simplenetwork
+{
+    parameters:
+        @display("bgb=512,395");
+        int numberOfClients = default(5);
+        int numberOfNormalFlows = default(1);
+        int numberOfLongerFlows = default(0);
+        int numberOfRouters = default(1);
+        volatile double minDelay @unit(s);
+
+    types:
+        channel ethernetline extends DatarateChannel
+        {
+            delay = minDelay;
+            datarate = 1Gbps;
+        }
+    submodules:
+        client[numberOfClients]: StandardHostRdp {
+            @display("p=162,225,m,n,$numberOfClients,150");
+        }
+        configurator: Ipv4NetworkConfiguratorEcmp {
+            @display("p=450,350");
+        }
+        server1: StandardHostRdp {
+            @display("p=464,117");
+        }
+        server2: StandardHostRdp {
+            @display("p=340,23");
+        }
+        router1: RouterRdp {
+            @display("p=162,117,m,n,$numberOfRouters,150");
+        }
+        router2: RouterRdp {
+            @display("p=340,117,m,n,$numberOfRouters,150");
+        }
+        broker: Broker;
+        stepper: Stepper;
+    connections:
+        client[0].pppg++ <--> ethernetline <--> router1.pppg++;
+        client[1].pppg++ <--> ethernetline <--> router1.pppg++;
+        router1.pppg++ <--> ethernetline <--> router2.pppg++;
+        client[2].pppg++ <--> ethernetline <--> router2.pppg++;
+        client[3].pppg++ <--> ethernetline <--> router2.pppg++;
+        client[4].pppg++ <--> ethernetline <--> router2.pppg++;
+        router2.pppg++ <--> ethernetline <--> server1.pppg++;
+        router2.pppg++ <--> ethernetline <--> server2.pppg++;
+}

--- a/src/base/RouterNdp.ned
+++ b/src/base/RouterNdp.ned
@@ -33,7 +33,7 @@ module RouterRdp extends ApplicationLayerNodeBaseEcmp
 {
     parameters:
         @display("i=abstract/router");
-        @figure[submodules];
+        //@figure[submodules];
         forwarding = true;
         bool hasOspf = default(false);
         bool hasRip = default(false);

--- a/src/node/ApplicationLayerNodeBaseEcmp.ned
+++ b/src/node/ApplicationLayerNodeBaseEcmp.ned
@@ -22,8 +22,8 @@ module ApplicationLayerNodeBaseEcmp extends TransportLayerNodeBaseEcmp
 {
     parameters:
         int numApps = default(0);
-        @figure[applicationLayer](type=rectangle; pos=250,6; size=1000,130; lineColor=#808080; cornerRadius=5; fillColor=#ffff00; fillOpacity=0.1);
-        @figure[applicationLayer.title](type=text; pos=1245,11; anchor=ne; text="application layer");
+        //@figure[applicationLayer](type=rectangle; pos=250,6; size=1000,130; lineColor=#808080; cornerRadius=5; fillColor=#ffff00; fillOpacity=0.1);
+        //@figure[applicationLayer.title](type=text; pos=1245,11; anchor=ne; text="application layer");
 
     submodules:
         app[numApps]: <> like IApp {

--- a/src/node/NetworkLayerNodeBaseEcmp.ned
+++ b/src/node/NetworkLayerNodeBaseEcmp.ned
@@ -28,8 +28,8 @@ module NetworkLayerNodeBaseEcmp extends LinkLayerNodeBase
         bool multicastForwarding = default(false);
         *.forwarding = forwarding;
         *.multicastForwarding = multicastForwarding;
-        @figure[networkLayer](type=rectangle; pos=250,306; size=1000,130; fillColor=#00ff00; lineColor=#808080; cornerRadius=5; fillOpacity=0.1);
-        @figure[networkLayer.title](type=text; pos=1245,311; anchor=ne; text="network layer");
+        //@figure[networkLayer](type=rectangle; pos=250,306; size=1000,130; fillColor=#00ff00; lineColor=#808080; cornerRadius=5; fillOpacity=0.1);
+        //@figure[networkLayer.title](type=text; pos=1245,311; anchor=ne; text="network layer");
 
     submodules:
         ipv4: <default("Ipv4NetworkLayerEcmp")> like INetworkLayer if hasIpv4 {

--- a/src/node/StandardHostNdp.ned
+++ b/src/node/StandardHostNdp.ned
@@ -17,7 +17,7 @@ module StandardHostRdp extends ApplicationLayerNodeBaseEcmp
 {
     parameters:
         @display("i=device/pc2");
-        @figure[submodules];
+        //@figure[submodules];
 		forwarding = default(false);
         *.routingTableModule = default("^.ipv4.routingTable");
 

--- a/src/node/TransportLayerNodeBaseEcmp.ned
+++ b/src/node/TransportLayerNodeBaseEcmp.ned
@@ -29,8 +29,8 @@ module TransportLayerNodeBaseEcmp extends NetworkLayerNodeBaseEcmp
         bool hasTcp = default(firstAvailableOrEmpty("Tcp", "TcpLwip", "TcpNsc") != "");
         bool hasSctp = default(false);
         bool hasRdp = default(firstAvailableOrEmpty("Rdp") != "");
-        @figure[transportLayer](type=rectangle; pos=250,156; size=1000,130; fillColor=#ff0000; lineColor=#808080; cornerRadius=5; fillOpacity=0.1);
-        @figure[transportLayer.title](type=text; pos=1245,161; anchor=ne; text="transport layer");
+        //@figure[transportLayer](type=rectangle; pos=250,156; size=1000,130; fillColor=#ff0000; lineColor=#808080; cornerRadius=5; fillOpacity=0.1);
+        //@figure[transportLayer.title](type=text; pos=1245,161; anchor=ne; text="transport layer");
     submodules:
         udp: <default(firstAvailableOrEmpty("Udp"))> like IUdp if hasUdp {
             parameters:

--- a/src/transportlayer/rdp/Rdp.cc
+++ b/src/transportlayer/rdp/Rdp.cc
@@ -452,7 +452,6 @@ void Rdp::printConnRequestMap()
 
 bool Rdp::allConnFinished()
 {
-//     std::cout << "  allConnFinished ?   "     << "\n";
     bool connDone;
 
     auto iter = requestCONNMap.begin();
@@ -471,7 +470,6 @@ bool Rdp::allConnFinished()
 
 void Rdp::updateConnMap()
 {
-    std::cout << "  updateConnMap updateConnMap   " << "\n";
     a: bool connDone;
     auto iter = requestCONNMap.begin();
 

--- a/src/transportlayer/rdp/RdpAlgorithm.h
+++ b/src/transportlayer/rdp/RdpAlgorithm.h
@@ -114,7 +114,7 @@ public:
 
     virtual void ackSent() = 0;
 
-    virtual void receivedHeader() = 0;
+    virtual void receivedHeader(unsigned int seqNum) = 0;
 
     virtual void receivedData(unsigned int seqNum) = 0;
 

--- a/src/transportlayer/rdp/RdpConnection.h
+++ b/src/transportlayer/rdp/RdpConnection.h
@@ -260,11 +260,11 @@ public:
     }
 
 protected:
-    /** Utility: cancel a timer */
-    cMessage* cancelEvent(cMessage *msg)
-    {
-        return rdpMain->cancelEvent(msg);
-    }
+    // /** Utility: cancel a timer */
+    // cMessage* cancelEvent(cMessage *msg)
+    // {
+    //     return rdpMain->cancelEvent(msg);
+    // }
 
     /** Utility: send IP packet */
     virtual void sendToIP(Packet *pkt, const Ptr<RdpHeader> &rdpseg, L3Address src, L3Address dest);
@@ -370,6 +370,8 @@ public:
 
     virtual void computeRtt(unsigned int pullSeqNum);
     virtual void rttMeasurementComplete(simtime_t newRtt);
+
+    virtual void cancelRequestTimer();
 
     /**
      * Utility: converts a given simtime to a timestamp (TS).

--- a/src/transportlayer/rdp/RdpConnection.h
+++ b/src/transportlayer/rdp/RdpConnection.h
@@ -286,7 +286,7 @@ public:
     /**
      * The "normal" constructor.
      */
-    void initConnection(Rdp *mod, int socketId);
+    virtual void initConnection(Rdp *mod, int socketId);
 
     /**
      * Destructor.

--- a/src/transportlayer/rdp/RdpConnection.h
+++ b/src/transportlayer/rdp/RdpConnection.h
@@ -5,6 +5,7 @@
 #include <inet/networklayer/common/L3Address.h>
 #include <inet/common/packet/ChunkQueue.h>
 #include <queue>
+#include <map>
 
 #include "../../transportlayer/rdp/Rdp.h"
 #include "../rdp/rdp_common/RdpHeader.h"
@@ -91,6 +92,23 @@ public:
     bool isfinalReceivedPrintedOut;
 
     bool sendPulls;
+
+    //Number of packets currently in flight. Inferred by IW and number of PR added
+    int packetsInFlight;
+
+    //RTT
+    simtime_t sRtt;
+    simtime_t minRtt;
+    simtime_t latestRtt;
+    simtime_t rttvar;
+
+    std::map<unsigned int, simtime_t> pullRequestsTransmissionTimes;
+
+    // TODO: remove these from here. 
+    //Step variables
+    simtime_t sRttStep;
+    simtime_t minRttStep;
+    simtime_t rttvarStep;
 };
 
 class INET_API RdpConnection : public cSimpleModule
@@ -349,6 +367,9 @@ public:
     virtual bool processAppCommand(cMessage *msg);
 
     virtual void handleMessage(cMessage *msg);
+
+    virtual void computeRtt(unsigned int pullSeqNum);
+    virtual void rttMeasurementComplete(simtime_t newRtt);
 
     /**
      * Utility: converts a given simtime to a timestamp (TS).

--- a/src/transportlayer/rdp/RdpConnection.h
+++ b/src/transportlayer/rdp/RdpConnection.h
@@ -67,7 +67,7 @@ public:
     int delayedNackNo;
     unsigned int request_id;
     unsigned int internal_request_id;
-    simtime_t pacingTime;
+    double pacingTime;
     int IW;  //initial window size
     int cwnd;
     int ssthresh;

--- a/src/transportlayer/rdp/RdpConnectionBase.cc
+++ b/src/transportlayer/rdp/RdpConnectionBase.cc
@@ -44,6 +44,15 @@ RdpStateVariables::RdpStateVariables()
     cwnd = 0;
     sendPulls = true;
     active = false;
+
+    sRtt = SIMTIME_ZERO;
+    minRtt  = SIMTIME_ZERO;
+    latestRtt = SIMTIME_ZERO;
+    rttvar = SIMTIME_ZERO;
+
+    sRttStep = SIMTIME_ZERO;
+    minRttStep = SIMTIME_ZERO;
+    rttvarStep = SIMTIME_ZERO;
 }
 
 std::string RdpStateVariables::str() const
@@ -114,6 +123,8 @@ bool RdpConnection::processTimer(cMessage *msg)
     return performStateTransition(event);
 }
 
+
+//TODO: this method should be called every time a packet (either trimmed or data is received)
 void RdpConnection::sendPullRequests()
 {
     std::cout << "\nPullQueue length - sending pull request " << pullQueue.getLength() << endl;

--- a/src/transportlayer/rdp/RdpConnectionBase.cc
+++ b/src/transportlayer/rdp/RdpConnectionBase.cc
@@ -84,7 +84,7 @@ void RdpConnection::initConnection(Rdp *_mod, int _socketId)
 
 RdpConnection::~RdpConnection()
 {
-    cancelEvent(paceTimerMsg);
+    cancelAndDelete(paceTimerMsg);
     std::list<PacketsToSend>::iterator iter;  // received iterator
 
     while (!receivedPacketsList.empty()) {
@@ -127,13 +127,11 @@ bool RdpConnection::processTimer(cMessage *msg)
 //TODO: this method should be called every time a packet (either trimmed or data is received)
 void RdpConnection::sendPullRequests()
 {
-    std::cout << "\nPullQueue length - sending pull request " << pullQueue.getLength() << endl;
     if(!paceTimerMsg->isScheduled()){
         if(pullQueue.getByteLength() > 0){
             sendRequestFromPullsQueue();
         }
         if(pullQueue.getByteLength() > 0){  //after popping a pull request, do any requests still exist within the queue
-            std::cout << "\n" << pullQueue.getLength() << endl;
             scheduleAt(simTime() + state->pacingTime, paceTimerMsg);
         }
     }

--- a/src/transportlayer/rdp/RdpConnectionRcvSegment.cc
+++ b/src/transportlayer/rdp/RdpConnectionRcvSegment.cc
@@ -146,12 +146,10 @@ RdpEventCode RdpConnection::processSegment1stThru8th(Packet *packet, const Ptr<c
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
     // header arrived at the receiver==> send new request with pacing (fixed pacing: MTU/1Gbps)
     if (rdpseg->isHeader() == true && rdpseg->isDataPacket() == false) { // 1 read, 2 write
-        EV_INFO << "Header arrived at the receiver" << endl;
-        sendNackRdp(rdpseg->getDataSequenceNumber());
         //state->receivedPacketsInWindow++;
         state->numRcvTrimmedHeader++;
         emit(trimmedHeadersSignal, state->numRcvTrimmedHeader);
-        rdpAlgorithm->receivedHeader();
+        rdpAlgorithm->receivedHeader(rdpseg->getDataSequenceNumber());
     }
     // (R.2) at the receiver
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
@@ -256,8 +254,6 @@ void RdpConnection::prepareInitialRequest(){
     getRDPMain()->connIndex++;
     state->connNotAddedYet = false;
     getRDPMain()->nap = true;    //TODO change to setter method
-    //EV << "Requesting Pull Timer" << endl;
-    //getRDPMain()->sendFirstRequest();
 }
 
 void RdpConnection::closeConnection(){

--- a/src/transportlayer/rdp/RdpConnectionUtil.cc
+++ b/src/transportlayer/rdp/RdpConnectionUtil.cc
@@ -284,8 +284,11 @@ void RdpConnection::rttMeasurementComplete(simtime_t newRtt){
 }
 
 void RdpConnection::computeRtt(unsigned int pullSeqNum){
+std::cout << "==================== TEST: " << pullSeqNum << std::endl;
+
     if (state->pullRequestsTransmissionTimes.find(pullSeqNum) != state->pullRequestsTransmissionTimes.end()){
         simtime_t rtt = simTime() - state->pullRequestsTransmissionTimes[pullSeqNum];
+        std::cout << "==================== Computed rtt: " << rtt << std::endl;
         state->pullRequestsTransmissionTimes.erase(pullSeqNum);
         rttMeasurementComplete(rtt);
     }
@@ -303,6 +306,13 @@ simtime_t RdpConnection::convertTSToSimtime(uint32 timestamp)
     ASSERT(SimTime::getScaleExp() <= -3);
     simtime_t simtime(timestamp, SIMTIME_MS);
     return simtime;
+}
+
+void RdpConnection::cancelRequestTimer(){
+    if(paceTimerMsg->isScheduled()){
+        cancelEvent(paceTimerMsg);
+
+    }
 }
 
 } // namespace rdp

--- a/src/transportlayer/rdp/RdpConnectionUtil.cc
+++ b/src/transportlayer/rdp/RdpConnectionUtil.cc
@@ -284,11 +284,8 @@ void RdpConnection::rttMeasurementComplete(simtime_t newRtt){
 }
 
 void RdpConnection::computeRtt(unsigned int pullSeqNum){
-std::cout << "==================== TEST: " << pullSeqNum << std::endl;
-
     if (state->pullRequestsTransmissionTimes.find(pullSeqNum) != state->pullRequestsTransmissionTimes.end()){
         simtime_t rtt = simTime() - state->pullRequestsTransmissionTimes[pullSeqNum];
-        std::cout << "==================== Computed rtt: " << rtt << std::endl;
         state->pullRequestsTransmissionTimes.erase(pullSeqNum);
         rttMeasurementComplete(rtt);
     }

--- a/src/transportlayer/rdp/RdpConnectionUtil.cc
+++ b/src/transportlayer/rdp/RdpConnectionUtil.cc
@@ -87,6 +87,10 @@ void RdpConnection::sendToIP(Packet *packet, const Ptr<RdpHeader> &rdpseg)
     auto addresses = packet->addTagIfAbsent<L3AddressReq>();
     addresses->setSrcAddress(localAddr);
     addresses->setDestAddress(remoteAddr);
+
+    //Set transmission time into packet header
+    ndpseg->setTransmissionTime(simTime());
+
     insertTransportProtocolHeader(packet, Protocol::rdp, rdpseg);
     rdpMain->sendFromConn(packet, "ipOut");
 }
@@ -100,6 +104,10 @@ void RdpConnection::sendToIP(Packet *packet, const Ptr<RdpHeader> &rdpseg, L3Add
     auto addresses = packet->addTagIfAbsent<L3AddressReq>();
     addresses->setSrcAddress(src);
     addresses->setDestAddress(dest);
+
+    //Set transmission time into packet header
+    ndpseg->setTransmissionTime(simTime());
+
 
     insertTransportProtocolHeader(packet, Protocol::rdp, rdpseg);
     rdpMain->sendFromConn(packet, "ipOut");

--- a/src/transportlayer/rdp/flavours/DumbRdp.cc
+++ b/src/transportlayer/rdp/flavours/DumbRdp.cc
@@ -45,7 +45,7 @@ void DumbRdp::ackSent()
 
 }
 
-void DumbRdp::receivedHeader()
+void DumbRdp::receivedHeader(unsigned int seqNum)
 {
 
 }

--- a/src/transportlayer/rdp/flavours/DumbRdp.h
+++ b/src/transportlayer/rdp/flavours/DumbRdp.h
@@ -53,7 +53,7 @@ class INET_API DumbRdp : public RdpAlgorithm
 
     virtual void ackSent() override;
 
-    virtual void receivedHeader() override;
+    virtual void receivedHeader(unsigned int seqNum) override;
 
     virtual void receivedData(unsigned int seqNum) override;
 

--- a/src/transportlayer/rdp/flavours/RdpAIMD.cc
+++ b/src/transportlayer/rdp/flavours/RdpAIMD.cc
@@ -127,8 +127,10 @@ void RdpAIMD::ackSent()
 //    conn->emit(cwndSignal, state->cwnd);
 //}
 
-void RdpAIMD::receivedHeader()
+void RdpAIMD::receivedHeader(unsigned int seqNum)
 {
+    EV_INFO << "Header arrived at the receiver" << endl;
+    conn->sendNackRdp(seqNum);
     bool noPacketsInFlight = false;
     if(state->outOfWindowPackets > 0){
         state->outOfWindowPackets--;

--- a/src/transportlayer/rdp/flavours/RdpAIMD.cc
+++ b/src/transportlayer/rdp/flavours/RdpAIMD.cc
@@ -15,7 +15,7 @@ RdpAIMDStateVariables::RdpAIMDStateVariables()
     internal_request_id = 0;
     request_id = 0;  // source block number (8-bit unsigned integer)
 
-    pacingTime = SimTime(1200, SIMTIME_US);
+    pacingTime = 1200/1000000;
 
     numPacketsToGet = 0;
     numPacketsToSend = 0;
@@ -258,7 +258,7 @@ void RdpAIMD::receivedData(unsigned int seqNum)
             conn->sendPacketToApp(seqNum);
         }
 
-        state->pacingTime = SimTime(100/state->cwnd, SIMTIME_MS);
+        state->pacingTime = (100/state->cwnd)/1000;
         if(conn->getPullsQueueLength() > 0){
             conn->sendPullRequests();
         }

--- a/src/transportlayer/rdp/flavours/RdpAIMD.h
+++ b/src/transportlayer/rdp/flavours/RdpAIMD.h
@@ -70,7 +70,7 @@ class INET_API RdpAIMD : public RdpAlgorithm
 
     virtual void ackSent() override;
 
-    virtual void receivedHeader() override;
+    virtual void receivedHeader(unsigned int seqNum) override;
 
     virtual void receivedData(unsigned int seqNum) override;
 

--- a/src/transportlayer/rdp/rdp_common/RdpHeader.msg
+++ b/src/transportlayer/rdp/rdp_common/RdpHeader.msg
@@ -42,6 +42,7 @@ class RdpHeader extends TransportHeaderBase
 	bool nackBit;
     bool rstBit; // RST: reset the connection
     bool synBit; // SYN: synchronize seq. numbers
+    simtime_t transmissionTime;
 }
 
 cplusplus(RdpHeader) {{


### PR DESCRIPTION
Still WIP.

- Removed the @figure annotations from NED files. This will cause problem when using Qtenv, so maybe we can just ignore changes to these files in the .gitignore and we keep them how we want locally.

- Added the virtual keyword to initConnection() in RdpConnection.h so that children classes can implement their own.

- Created a separate folder for RL based simulations. I may remove that.

- Added experimental timestamp field in Rdp header. This is just experimental and can't be used in prctice. We will need to implement a pragmatic approach to RTT calculation.

- NACKs are now triggered by the RdpAlgorithm class rather than the connection.

- Added RTT measurement based on PR sequence number. 